### PR TITLE
Bump node.js version to 6.11.1 due to security vulnerability

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
   environment:
     CI: true
   node:
-    version: 5.11.0
+    version: 6.11.1
 
 checkout:
   post:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://git.heroku.com/ft-six-degrees-be-app.git"
   },
   "engines": {
-    "node": "6.11.1"
+    "node": "^6.11.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "https://git.heroku.com/ft-six-degrees-be-app.git"
   },
-  "engines": {
-    "node": "^6.11.1"
-  },
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://git.heroku.com/ft-six-degrees-be-app.git"
   },
   "engines": {
-    "node": "6.9.1"
+    "node": "6.11.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
See:
https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/